### PR TITLE
Add support for FARGATE-SPOT capacity provider and extend task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-ecs-fargate
 
-Terraform module to create AWS ECS FARGATE services.
+Terraform module to create AWS ECS FARGATE services. Module support both FARGATE and FARGATE-SPOT capacity provider settings.
 
 ## Terraform versions
 
@@ -8,16 +8,27 @@ Terraform 0.12. Pin module version to `~> v1.0`. Submit pull-requests to `master
 
 ## Usage
 
-### Application Load Balancer
+### ECS Fargate Service
 
 ```hcl
 resource "aws_ecs_cluster" "cluster" {
   name = "example-ecs-cluster"
+
+  capacity_providers = ["FARGATE_SPOT", "FARGATE"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+  }
+
+  setting {
+    name  = "containerInsights"
+    value = "disabled"
+  }
 }
 
 module "ecs-farage" {
   source = "umotif-public/ecs-fargate/aws"
-  version = "~> 1.0"
+  version = "~> 1.1"
 
   name_prefix        = "ecs-fargate-example"
   vpc_id             = "vpc-abasdasd132"
@@ -39,6 +50,7 @@ module "ecs-farage" {
   }
 
   tags = {
+    Environment = "test"
     Project = "Test"
   }
 }
@@ -51,6 +63,7 @@ Module is to be used with Terraform > 0.12.
 ## Examples
 
 * [ECS Fargate](https://github.com/umotif-public/terraform-aws-ecs-fargate/tree/master/examples/core)
+* [ECS Fargate Spot](https://github.com/umotif-public/terraform-aws-ecs-fargate/tree/master/examples/fargate-spot)
 
 ## Authors
 
@@ -61,12 +74,14 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| capacity\_provider\_strategy | \(Optional\) The capacity\_provider\_strategy configuration block. This is a list of maps, where each map should contain "capacity\_provider ", "weight" and "base" | list | `[]` | no |
 | cluster\_id | The Amazon Resource Name \(ARN\) that identifies the cluster. | string | n/a | yes |
 | container\_name | Optional name for the container to be used instead of name\_prefix. | string | `""` | no |
 | deployment\_controller\_type | Type of deployment controller. Valid values: CODE\_DEPLOY, ECS. | string | `"ECS"` | no |
 | deployment\_maximum\_percent | The upper limit of the number of running tasks that can be running in a service during a deployment | number | `"200"` | no |
 | deployment\_minimum\_healthy\_percent | The lower limit of the number of running tasks that must remain running and healthy in a service during a deployment | number | `"50"` | no |
 | desired\_count | The number of instances of the task definitions to place and keep running. | number | `"1"` | no |
+| docker\_volume\_configuration | \(Optional\) Used to configure a docker volume option "docker\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html | list | `[]` | no |
 | health\_check | A health block containing health check settings for the target group. Overrides the defaults. | map(string) | n/a | yes |
 | health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers. | number | `"300"` | no |
 | lb\_arn | Arn for the LB for which the service should be attach to. | string | n/a | yes |
@@ -74,8 +89,10 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | log\_retention\_in\_days | Number of days the logs will be retained in CloudWatch. | number | `"30"` | no |
 | logs\_kms\_key | The KMS key ARN to use to encrypt container logs. | string | `""` | no |
 | name\_prefix | A prefix used for naming resources. | string | n/a | yes |
+| placement\_constraints | \(Optional\) A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement\_constraints is 10. This is a list of maps, where each map should contain "type" and "expression" | list | `[]` | no |
 | private\_subnet\_ids | A list of private subnets inside the VPC | list(string) | n/a | yes |
 | propogate\_tags | Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are SERVICE and TASK\_DEFINITION. | string | `"TASK_DEFINITION"` | no |
+| proxy\_configuration | \(Optional\) The proxy configuration details for the App Mesh proxy. This is a list of maps, where each map should contain "container\_name", "properties" and "type" | list | `[]` | no |
 | repository\_credentials | name or ARN of a secrets manager secret \(arn:aws:secretsmanager:region:aws\_account\_id:secret:secret\_name\) | string | `""` | no |
 | repository\_credentials\_kms\_key | key id, key ARN, alias name or alias ARN of the key that encrypted the repository credentials | string | `"alias/aws/secretsmanager"` | no |
 | service\_registry\_arn | ARN of aws\_service\_discovery\_service resource | string | `""` | no |
@@ -90,6 +107,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | task\_definition\_cpu | Amount of CPU to reserve for the task. | number | `"256"` | no |
 | task\_definition\_memory | The soft limit \(in MiB\) of memory to reserve for the container. | number | `"512"` | no |
 | task\_host\_port | The port number on the container instance to reserve for your container. | number | `"0"` | no |
+| volume | \(Optional\) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain "name", "host\_path" and "docker\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html | list | `[]` | no |
 | vpc\_id | The VPC ID. | string | n/a | yes |
 
 ## Outputs

--- a/examples/fargate-spot/main.tf
+++ b/examples/fargate-spot/main.tf
@@ -1,0 +1,114 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+#####
+# VPC and subnets
+#####
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 2.21"
+
+  name = "simple-vpc"
+
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway = false
+}
+
+#####
+# ALB
+#####
+module "alb" {
+  source  = "umotif-public/alb/aws"
+  version = "~> 1.0"
+
+  name_prefix        = "alb-example"
+  load_balancer_type = "application"
+  internal           = false
+  vpc_id             = module.vpc.vpc_id
+  subnets            = module.vpc.public_subnets
+}
+
+resource "aws_lb_listener" "alb_80" {
+  load_balancer_arn = module.alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = module.fargate.target_group_arn
+  }
+}
+
+#####
+# Security Group Config
+#####
+resource "aws_security_group_rule" "alb_ingress_80" {
+  security_group_id = module.alb.security_group_id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}
+
+resource "aws_security_group_rule" "task_ingress_80" {
+  security_group_id        = module.fargate.service_sg_id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 80
+  to_port                  = 80
+  source_security_group_id = module.alb.security_group_id
+}
+
+#####
+# ECS cluster and fargate
+#####
+resource "aws_ecs_cluster" "cluster" {
+  name               = "ecs-spot-test"
+  capacity_providers = ["FARGATE_SPOT", "FARGATE"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+  }
+
+  setting {
+    name  = "containerInsights"
+    value = "disabled"
+  }
+}
+
+module "fargate" {
+  source = "../../"
+
+  name_prefix        = "ecs-fargate-example"
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.public_subnets
+  lb_arn             = module.alb.arn
+  cluster_id         = aws_ecs_cluster.cluster.id
+
+  task_container_image   = "marcincuber/2048-game:latest"
+  task_definition_cpu    = 256
+  task_definition_memory = 512
+
+  task_container_port             = 80
+  task_container_assign_public_ip = true
+
+  health_check = {
+    port = "traffic-port"
+    path = "/"
+  }
+
+  capacity_provider_strategy = [
+    {
+      capacity_provider = "FARGATE_SPOT",
+      weight            = 100
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -170,3 +170,33 @@ variable "logs_kms_key" {
   description = "The KMS key ARN to use to encrypt container logs."
   default     = ""
 }
+
+variable "capacity_provider_strategy" {
+  type        = list
+  description = "(Optional) The capacity_provider_strategy configuration block. This is a list of maps, where each map should contain \"capacity_provider \", \"weight\" and \"base\""
+  default     = []
+}
+
+variable "placement_constraints" {
+  type        = list
+  description = "(Optional) A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement_constraints is 10. This is a list of maps, where each map should contain \"type\" and \"expression\""
+  default     = []
+}
+
+variable "proxy_configuration" {
+  type        = list
+  description = "(Optional) The proxy configuration details for the App Mesh proxy. This is a list of maps, where each map should contain \"container_name\", \"properties\" and \"type\""
+  default     = []
+}
+
+variable "volume" {
+  type        = list
+  description = "(Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain \"name\", \"host_path\" and \"docker_volume_configuration\". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html"
+  default     = []
+}
+
+variable "docker_volume_configuration" {
+  type        = list
+  description = "(Optional) Used to configure a docker volume option \"docker_volume_configuration\". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html"
+  default     = []
+}


### PR DESCRIPTION
# Description

- Add support + example for FARGATE-SPOT capacity provider
- Add support for task definition options: placement_constraints, proxy_configuration, volume and docker_volume_configuration
- Update docs