### PR TITLE
Improve security group creation/deletion and switch to using prefix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v3.0.1
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ No requirements.
 | repository\_credentials | name or ARN of a secrets manager secret (arn:aws:secretsmanager:region:aws\_account\_id:secret:secret\_name) | `string` | `""` | no |
 | repository\_credentials\_kms\_key | key id, key ARN, alias name or alias ARN of the key that encrypted the repository credentials | `string` | `"alias/aws/secretsmanager"` | no |
 | service\_registry\_arn | ARN of aws\_service\_discovery\_service resource | `string` | `""` | no |
+| sg\_name\_prefix | A prefix used for Security group name. | `string` | `""` | no |
 | tags | A map of tags (key-value pairs) passed to resources. | `map(string)` | `{}` | no |
 | target\_group\_name | The name for the tasks target group | `string` | `""` | no |
 | task\_container\_assign\_public\_ip | Assigned public IP to the container. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -50,14 +50,20 @@ resource "aws_iam_role_policy" "log_agent" {
 #####
 resource "aws_security_group" "ecs_service" {
   vpc_id      = var.vpc_id
-  name        = "${var.name_prefix}-ecs-service-sg"
+  name_prefix = var.sg_name_prefix == "" ? "${var.name_prefix}-ecs-service-sg-" : "${var.sg_name_prefix}-"
   description = "Fargate service security group"
   tags = merge(
     var.tags,
     {
-      Name = "${var.name_prefix}-sg"
+      Name = var.sg_name_prefix == "" ? "${var.name_prefix}-ecs-service-sg" : "${var.sg_name_prefix}"
     },
   )
+
+  revoke_rules_on_delete = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "egress_service" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "sg_name_prefix" {
+  description = "A prefix used for Security group name."
+  type        = string
+  default     = ""
+}
+
 variable "container_name" {
   description = "Optional name for the container to be used instead of name_prefix."
   default     = ""


### PR DESCRIPTION
# Description

- Allow for security group to be created and deleted without failing. 
- sg_name_prefix variable add to allow for custom name.

**Breaking change,** this will require to create a new security group and old ecs task will be blocking deletion of old security group. This can be solved by removing manually old tasks. New tasks will be running at that stage so application will not experience any downtime. (This is applicable when upgrading module from 1.X to 2.X.

This PR with form part of 2.0.0 release.