### PR TITLE
Lock minimum version of provider and add force_new_deployment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.0.1
+  rev: v3.1.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']

--- a/README.md
+++ b/README.md
@@ -73,13 +73,15 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | ~> 2.63 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.63 |
 | null | n/a |
 
 ## Inputs
@@ -94,6 +96,7 @@ No requirements.
 | deployment\_maximum\_percent | The upper limit of the number of running tasks that can be running in a service during a deployment | `number` | `200` | no |
 | deployment\_minimum\_healthy\_percent | The lower limit of the number of running tasks that must remain running and healthy in a service during a deployment | `number` | `50` | no |
 | desired\_count | The number of instances of the task definitions to place and keep running. | `number` | `1` | no |
+| force\_new\_deployment | Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version. | `bool` | `false` | no |
 | health\_check | A health block containing health check settings for the target group. Overrides the defaults. | `map(string)` | n/a | yes |
 | health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers. | `number` | `300` | no |
 | lb\_arn | Arn for the LB for which the service should be attach to. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terraform module to create AWS ECS FARGATE services. Module support both FARGATE
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
+Terraform 0.12. Pin module version to `~> v3.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
@@ -28,7 +28,7 @@ resource "aws_ecs_cluster" "cluster" {
 
 module "ecs-farage" {
   source = "umotif-public/ecs-fargate/aws"
-  version = "~> 2.0.0"
+  version = "~> 3.0.0"
 
   name_prefix        = "ecs-fargate-example"
   vpc_id             = "vpc-abasdasd132"

--- a/main.tf
+++ b/main.tf
@@ -264,6 +264,8 @@ resource "aws_ecs_service" "service" {
   platform_version = var.platform_version
   launch_type      = length(var.capacity_provider_strategy) == 0 ? "FARGATE" : null
 
+  force_new_deployment = var.force_new_deployment
+
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   deployment_maximum_percent         = var.deployment_maximum_percent
   health_check_grace_period_seconds  = var.load_balanced ? var.health_check_grace_period_seconds : null

--- a/variables.tf
+++ b/variables.tf
@@ -259,3 +259,9 @@ variable "task_mount_points" {
   default     = null
 }
 
+variable "force_new_deployment" {
+  type        = bool
+  description = "Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version."
+  default     = false
+}
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    aws = "~> 2.63"
+  }
+}


### PR DESCRIPTION
# Description

- Add support for ecs_service argument force_new_deployment
- Add minimum provider version and set to ~> 2.63

This will be part of 3.0.0 release.