### PR TITLE
Major upgrade to v5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.3.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.31.0
+  rev: v1.44.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,25 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Update module versions to support v3 provider
+- Add upgrades
+
+
+<a name="4.0.3"></a>
+## [4.0.3] - 2020-10-13
+
+- Update main.tf ([#23](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/23))
+
+
+<a name="4.0.2"></a>
+## [4.0.2] - 2020-10-02
+
+- Fix log group permissions ([#22](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/22))
+
+
+<a name="4.0.1"></a>
+## [4.0.1] - 2020-08-05
+
+- Feature/v3 provider support ([#21](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/21))
 
 
 <a name="4.0.0"></a>
@@ -137,7 +155,10 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/4.0.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/4.0.3...HEAD
+[4.0.3]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/4.0.2...4.0.3
+[4.0.2]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/4.0.1...4.0.2
+[4.0.1]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/3.0.2...4.0.0
 [3.0.2]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/3.0.1...3.0.2
 [3.0.1]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/3.0.0...3.0.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terraform module to create AWS ECS FARGATE services. Module support both FARGATE
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v4.0`. Submit pull-requests to `master` branch.
+Terraform 0.13. Pin module version to `~> v5.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
@@ -28,7 +28,7 @@ resource "aws_ecs_cluster" "cluster" {
 
 module "ecs-fargate" {
   source = "umotif-public/ecs-fargate/aws"
-  version = "~> 4.0.0"
+  version = "~> 5.0.0"
 
   name_prefix        = "ecs-fargate-example"
   vpc_id             = "vpc-abasdasd132"
@@ -58,7 +58,7 @@ module "ecs-fargate" {
 
 ## Assumptions
 
-Module is to be used with Terraform > 0.12.
+Module is to be used with Terraform > 0.13.
 
 ## Examples
 
@@ -75,15 +75,14 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 2.68, < 4.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 3.13 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.68, < 4.0 |
-| null | n/a |
+| aws | >= 3.13 |
 
 ## Inputs
 
@@ -135,6 +134,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | task\_stop\_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own. The max stop timeout value is 120 seconds and if the parameter is not specified, the default value of 30 seconds is used. | `number` | `null` | no |
 | volume | (Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain "name", "host\_path", "docker\_volume\_configuration" and "efs\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html | `list` | `[]` | no |
 | vpc\_id | The VPC ID. | `string` | n/a | yes |
+| wait\_for\_steady\_state | If true, Terraform will wait for the service to reach a steady state (like aws ecs wait services-stable) before continuing. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 #####
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.32"
+  version = "~> 2.63"
 
   name = "simple-vpc"
 
@@ -98,6 +98,8 @@ module "fargate" {
   lb_arn             = module.alb.arn
   cluster_id         = aws_ecs_cluster.cluster.id
 
+  wait_for_steady_state = true
+
   platform_version = "1.4.0" # defaults to LATEST
 
   task_container_image   = "marcincuber/2048-game:latest"
@@ -113,6 +115,10 @@ module "fargate" {
   }
 
   task_stop_timeout = 90
+
+  depends_on = [
+    module.alb
+  ]
 
   ### To use task credentials, below paramaters are required
   # create_repository_credentials_iam_policy = false

--- a/examples/fargate-efs/main.tf
+++ b/examples/fargate-efs/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 #####
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.21"
+  version = "~> 2.63"
 
   name = "simple-vpc"
 
@@ -145,5 +145,9 @@ module "fargate" {
         }
       ]
     }
+  ]
+
+  depends_on = [
+    module.alb
   ]
 }

--- a/examples/fargate-spot/main.tf
+++ b/examples/fargate-spot/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 #####
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.21"
+  version = "~> 2.63"
 
   name = "simple-vpc"
 
@@ -110,5 +110,9 @@ module "fargate" {
       capacity_provider = "FARGATE_SPOT",
       weight            = 100
     }
+  ]
+
+  depends_on = [
+    module.alb
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -264,3 +264,8 @@ variable "force_new_deployment" {
   default     = false
 }
 
+variable "wait_for_steady_state" {
+  type        = bool
+  description = "If true, Terraform will wait for the service to reach a steady state (like aws ecs wait services-stable) before continuing."
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 2.68, < 4.0"
+    aws = ">= 3.13"
   }
 }


### PR DESCRIPTION
# Description

- Min version of terraform set to 13
- Min version of terraform provider set to 3.13
- Add support for terraform 14
- Drop support for terraform 12
- Support for `wait_for_steady_state` ecs service parameter
- Update examples and docs
- remove null service, terraform 0.13 supports depends_on block for modules

This PR forms version 5.0.0 of the module