### PR TITLE
Add secrets to task defintion

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -200,7 +200,7 @@ resource "aws_ecs_task_definition" "task" {
   %{~endif}
   "environment": ${jsonencode(local.task_environment)}
   %{if var.task_container_memory != null~}
-  "secrets": ${jsonencode(var.secrets)}
+  "secrets": ${jsonencode(var.task_container_secrets)}
   %{~endif}
 }]
 EOF

--- a/main.tf
+++ b/main.tf
@@ -199,7 +199,7 @@ resource "aws_ecs_task_definition" "task" {
   "mountPoints": ${jsonencode(var.task_mount_points)},
   %{~endif}
   "environment": ${jsonencode(local.task_environment)}
-  %{if var.task_container_memory != null~}
+  %{if var.task_container_secrets != null~}
   "secrets": ${jsonencode(var.task_container_secrets)}
   %{~endif}
 }]

--- a/main.tf
+++ b/main.tf
@@ -198,10 +198,10 @@ resource "aws_ecs_task_definition" "task" {
   %{if var.task_mount_points != null~}
   "mountPoints": ${jsonencode(var.task_mount_points)},
   %{~endif}
-  "environment": ${jsonencode(local.task_environment)}
   %{if var.task_container_secrets != null~}
-  "secrets": ${jsonencode(var.task_container_secrets)}
+  "secrets": ${jsonencode(var.task_container_secrets)},
   %{~endif}
+  "environment": ${jsonencode(local.task_environment)}
 }]
 EOF
 

--- a/main.tf
+++ b/main.tf
@@ -199,6 +199,9 @@ resource "aws_ecs_task_definition" "task" {
   "mountPoints": ${jsonencode(var.task_mount_points)},
   %{~endif}
   "environment": ${jsonencode(local.task_environment)}
+  %{if var.task_container_memory != null~}
+  "secrets": ${jsonencode(var.secrets)}
+  %{~endif}
 }]
 EOF
 

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,12 @@ variable "task_container_environment" {
   type        = map(string)
 }
 
+variable "task_container_secrets" {
+  description = "The secrets variables to pass to a container."
+  default     = null
+  type        = map(string)
+}
+
 variable "log_retention_in_days" {
   description = "Number of days the logs will be retained in CloudWatch."
   default     = 30

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "task_container_environment" {
 variable "task_container_secrets" {
   description = "The secrets variables to pass to a container."
   default     = null
-  type        = map(string)
+  type        = list(map(string))
 }
 
 variable "log_retention_in_days" {


### PR DESCRIPTION
# Description
Fix issue #27: Added in variable `task_container_secrets` and a conditional entry into the task definition JSON to pass secrets to it.