### PR TITLE
Add support for registering multiple target groups with a service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ crash.log
 terraform.tfstate
 *.tfstate*
 terraform.tfvars
+*.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module to create AWS ECS FARGATE services. Module support both FARGATE
 
 ## Terraform versions
 
-Terraform 0.13. Pin module version to `~> v5.0`. Submit pull-requests to `master` branch.
+Terraform 0.13. Pin module version to `~> v6.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
@@ -30,12 +30,11 @@ resource "aws_ecs_cluster" "cluster" {
 
 module "ecs-fargate" {
   source = "umotif-public/ecs-fargate/aws"
-  version = "~> 5.1.0"
+  version = "~> 6.0.0"
 
   name_prefix        = "ecs-fargate-example"
   vpc_id             = "vpc-abasdasd132"
   private_subnet_ids = ["subnet-abasdasd132123", "subnet-abasdasd132123132"]
-  lb_arn             = "arn:aws:asdasdasdasdasdasad"
 
   cluster_id         = aws_ecs_cluster.cluster.id
 
@@ -45,6 +44,13 @@ module "ecs-fargate" {
 
   task_container_port             = 80
   task_container_assign_public_ip = true
+
+  target_groups = [
+    {
+      target_group_name = "tg-fargate-example"
+      container_port    = 80
+    }
+  ]
 
   health_check = {
     port = "traffic-port"

--- a/README.md
+++ b/README.md
@@ -100,14 +100,13 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | cluster\_id | The Amazon Resource Name (ARN) that identifies the cluster. | `string` | n/a | yes |
 | container\_name | Optional name for the container to be used instead of name\_prefix. | `string` | `""` | no |
 | create\_repository\_credentials\_iam\_policy | Set to true if you are specifying `repository_credentials` variable, it will attach IAM policy with necessary permissions to task role. | `bool` | `false` | no |
-| deployment\_controller\_type | Type of deployment controller. Valid values: CODE\_DEPLOY, ECS. | `string` | `"ECS"` | no |
+| deployment\_controller\_type | Type of deployment controller. Valid values: CODE\_DEPLOY, ECS, EXTERNAL. Default: ECS. | `string` | `"ECS"` | no |
 | deployment\_maximum\_percent | The upper limit of the number of running tasks that can be running in a service during a deployment | `number` | `200` | no |
 | deployment\_minimum\_healthy\_percent | The lower limit of the number of running tasks that must remain running and healthy in a service during a deployment | `number` | `50` | no |
 | desired\_count | The number of instances of the task definitions to place and keep running. | `number` | `1` | no |
 | force\_new\_deployment | Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version. | `bool` | `false` | no |
 | health\_check | A health block containing health check settings for the target group. Overrides the defaults. | `map(string)` | n/a | yes |
 | health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers. | `number` | `300` | no |
-| lb\_arn | Arn for the LB for which the service should be attach to. | `string` | n/a | yes |
 | load\_balanced | Whether the task should be loadbalanced. | `bool` | `true` | no |
 | log\_retention\_in\_days | Number of days the logs will be retained in CloudWatch. | `number` | `30` | no |
 | logs\_kms\_key | The KMS key ARN to use to encrypt container logs. | `string` | `""` | no |
@@ -122,7 +121,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | service\_registry\_arn | ARN of aws\_service\_discovery\_service resource | `string` | `""` | no |
 | sg\_name\_prefix | A prefix used for Security group name. | `string` | `""` | no |
 | tags | A map of tags (key-value pairs) passed to resources. | `map(string)` | `{}` | no |
-| target\_group\_name | The name for the tasks target group | `string` | `""` | no |
+| target\_groups | The name of the target groups to associate with ecs service | `any` | `[]` | no |
 | task\_container\_assign\_public\_ip | Assigned public IP to the container. | `bool` | `false` | no |
 | task\_container\_command | The command that is passed to the container. | `list(string)` | `[]` | no |
 | task\_container\_cpu | Amount of CPU to reserve for the container. | `number` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/umotif-public/terraform-aws-ecs-fargate?style=social)
+<!-- markdownlint-disable MD041 -->
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/umotif-public/terraform-aws-ecs-fargate?style=social)](https://github.com/umotif-public/terraform-aws-ecs-fargate/releases/latest)
 
-# terraform-aws-ecs-fargate
+# Terraform AWS ECS Fargate
 
-Terraform module to create AWS ECS FARGATE services. Module support both FARGATE and FARGATE-SPOT capacity provider settings.
+Terraform module to create [AWS ECS FARGATE](https://aws.amazon.com/fargate/) services. Module supports both `FARGATE` and `FARGATE-SPOT` capacity provider settings.
 
 ## Terraform versions
 
@@ -73,6 +74,7 @@ Module is to be used with Terraform > 0.13.
 * [ECS Fargate](https://github.com/umotif-public/terraform-aws-ecs-fargate/tree/master/examples/core)
 * [ECS Fargate Spot](https://github.com/umotif-public/terraform-aws-ecs-fargate/tree/master/examples/fargate-spot)
 * [ECS Fargate with EFS](https://github.com/umotif-public/terraform-aws-ecs-fargate/tree/master/examples/fargate-efs)
+* [ECS Service with multiple target groups](https://github.com/umotif-public/terraform-aws-ecs-fargate/tree/master/examples/multiple-target-groups)
 
 ## Authors
 

--- a/examples/fargate-efs/main.tf
+++ b/examples/fargate-efs/main.tf
@@ -5,19 +5,12 @@ provider "aws" {
 #####
 # VPC and subnets
 #####
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.63"
+data "aws_vpc" "default" {
+  default = true
+}
 
-  name = "simple-vpc"
-
-  cidr = "10.0.0.0/16"
-
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-
-  enable_nat_gateway = false
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
 }
 
 #####
@@ -25,13 +18,13 @@ module "vpc" {
 #####
 module "alb" {
   source  = "umotif-public/alb/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   name_prefix        = "alb-example"
   load_balancer_type = "application"
   internal           = false
-  vpc_id             = module.vpc.vpc_id
-  subnets            = module.vpc.public_subnets
+  vpc_id             = data.aws_vpc.default.id
+  subnets            = data.aws_subnet_ids.all.ids
 }
 
 resource "aws_lb_listener" "alb_80" {
@@ -41,7 +34,7 @@ resource "aws_lb_listener" "alb_80" {
 
   default_action {
     type             = "forward"
-    target_group_arn = module.fargate.target_group_arn
+    target_group_arn = module.fargate.target_group_arn[0]
   }
 }
 
@@ -99,9 +92,8 @@ module "fargate" {
   source = "../../"
 
   name_prefix        = "ecs-fargate-example"
-  vpc_id             = module.vpc.vpc_id
-  private_subnet_ids = module.vpc.public_subnets
-  lb_arn             = module.alb.arn
+  vpc_id             = data.aws_vpc.default.id
+  private_subnet_ids = data.aws_subnet_ids.all.ids
   cluster_id         = aws_ecs_cluster.cluster.id
 
   platform_version = "1.4.0"
@@ -112,6 +104,12 @@ module "fargate" {
 
   task_container_port             = 80
   task_container_assign_public_ip = true
+
+  target_groups = [
+    {
+      container_port = 80
+    }
+  ]
 
   health_check = {
     port = "traffic-port"

--- a/examples/fargate-spot/main.tf
+++ b/examples/fargate-spot/main.tf
@@ -84,7 +84,7 @@ module "fargate" {
   vpc_id             = data.aws_vpc.default.id
   private_subnet_ids = data.aws_subnet_ids.all.ids
 
-  cluster_id         = aws_ecs_cluster.cluster.id
+  cluster_id = aws_ecs_cluster.cluster.id
 
   task_container_image   = "marcincuber/2048-game:latest"
   task_definition_cpu    = 256

--- a/examples/multiple-target-groups/main.tf
+++ b/examples/multiple-target-groups/main.tf
@@ -169,7 +169,6 @@ module "fargate" {
   # repository_credentials                   = aws_secretsmanager_secret.task_credentials.arn
 }
 
-
 resource "aws_security_group" "allow_sg_test" {
   name        = "allow_sg_test"
   description = "Allow sg inbound traffic"

--- a/examples/multiple-target-groups/main.tf
+++ b/examples/multiple-target-groups/main.tf
@@ -16,19 +16,19 @@ data "aws_subnet_ids" "all" {
 #####
 # ALB
 #####
-module "alb" {
+module "external-alb" {
   source  = "umotif-public/alb/aws"
   version = "~> 2.0"
 
-  name_prefix        = "alb-example"
+  name_prefix        = "alb-external-example"
   load_balancer_type = "application"
   internal           = false
   vpc_id             = data.aws_vpc.default.id
   subnets            = data.aws_subnet_ids.all.ids
 }
 
-resource "aws_lb_listener" "alb_80" {
-  load_balancer_arn = module.alb.arn
+resource "aws_lb_listener" "external_alb_80" {
+  load_balancer_arn = module.external-alb.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -38,11 +38,33 @@ resource "aws_lb_listener" "alb_80" {
   }
 }
 
+module "internal-alb" {
+  source  = "umotif-public/alb/aws"
+  version = "~> 2.0"
+
+  name_prefix        = "alb-internal-example"
+  load_balancer_type = "application"
+  internal           = false
+  vpc_id             = data.aws_vpc.default.id
+  subnets            = data.aws_subnet_ids.all.ids
+}
+
+resource "aws_lb_listener" "internal_alb_80" {
+  load_balancer_arn = module.internal-alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = module.fargate.target_group_arn[1]
+  }
+}
+
 #####
 # Security Group Config
 #####
-resource "aws_security_group_rule" "alb_ingress_80" {
-  security_group_id = module.alb.security_group_id
+resource "aws_security_group_rule" "alb_external_ingress_80" {
+  security_group_id = module.external-alb.security_group_id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 80
@@ -51,13 +73,32 @@ resource "aws_security_group_rule" "alb_ingress_80" {
   ipv6_cidr_blocks  = ["::/0"]
 }
 
-resource "aws_security_group_rule" "task_ingress_80" {
+resource "aws_security_group_rule" "internal_task_ingress_80" {
   security_group_id        = module.fargate.service_sg_id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 80
   to_port                  = 80
-  source_security_group_id = module.alb.security_group_id
+  source_security_group_id = module.external-alb.security_group_id
+}
+
+resource "aws_security_group_rule" "alb_internal_ingress_80" {
+  security_group_id = module.internal-alb.security_group_id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}
+
+resource "aws_security_group_rule" "external_task_ingress_80" {
+  security_group_id        = module.fargate.service_sg_id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 80
+  to_port                  = 80
+  source_security_group_id = module.internal-alb.security_group_id
 }
 
 #####
@@ -89,6 +130,16 @@ module "fargate" {
   vpc_id             = data.aws_vpc.default.id
   private_subnet_ids = data.aws_subnet_ids.all.ids
   cluster_id         = aws_ecs_cluster.cluster.id
+  target_groups      = [
+    {
+      target_group_name  = "external-alb"
+      container_port     = 80
+    },
+    {
+      target_group_name = "internal-alb"
+      container_port    = 80
+    }
+  ]
 
   wait_for_steady_state = true
 
@@ -101,12 +152,6 @@ module "fargate" {
   task_container_port             = 80
   task_container_assign_public_ip = true
 
-  target_groups = [
-    {
-      container_port = 80
-    }
-  ]
-
   health_check = {
     port = "traffic-port"
     path = "/"
@@ -115,7 +160,8 @@ module "fargate" {
   task_stop_timeout = 90
 
   depends_on = [
-    module.alb
+    module.external-alb,
+    module.internal-alb
   ]
 
   ### To use task credentials, below paramaters are required

--- a/examples/multiple-target-groups/main.tf
+++ b/examples/multiple-target-groups/main.tf
@@ -130,10 +130,10 @@ module "fargate" {
   vpc_id             = data.aws_vpc.default.id
   private_subnet_ids = data.aws_subnet_ids.all.ids
   cluster_id         = aws_ecs_cluster.cluster.id
-  target_groups      = [
+  target_groups = [
     {
-      target_group_name  = "external-alb"
-      container_port     = 80
+      target_group_name = "external-alb"
+      container_port    = 80
     },
     {
       target_group_name = "internal-alb"

--- a/main.tf
+++ b/main.tf
@@ -312,7 +312,7 @@ resource "aws_ecs_service" "service" {
   }
 
   deployment_controller {
-    type = var.deployment_controller_type # CODE_DEPLOY or ECS
+    type = var.deployment_controller_type # CODE_DEPLOY or ECS or EXTERNAL
   }
 
   dynamic "service_registries" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,12 +5,12 @@ output "service_arn" {
 
 output "target_group_arn" {
   description = "The ARN of the Target Group used by Load Balancer."
-  value       = concat(aws_lb_target_group.task[*].arn, [""])[0]
+  value       = [for tg_arn in aws_lb_target_group.task : tg_arn.arn ]
 }
 
 output "target_group_name" {
   description = "The Name of the Target Group used by Load Balancer."
-  value       = concat(aws_lb_target_group.task[*].name, [""])[0]
+  value       = [for tg_name in aws_lb_target_group.task : tg_name.name ]
 }
 
 output "task_role_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,12 +5,12 @@ output "service_arn" {
 
 output "target_group_arn" {
   description = "The ARN of the Target Group used by Load Balancer."
-  value       = [for tg_arn in aws_lb_target_group.task : tg_arn.arn ]
+  value       = [for tg_arn in aws_lb_target_group.task : tg_arn.arn]
 }
 
 output "target_group_name" {
   description = "The Name of the Target Group used by Load Balancer."
-  value       = [for tg_name in aws_lb_target_group.task : tg_name.name ]
+  value       = [for tg_name in aws_lb_target_group.task : tg_name.name]
 }
 
 output "task_role_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -189,19 +189,19 @@ variable "logs_kms_key" {
 }
 
 variable "capacity_provider_strategy" {
-  type        = list
+  type        = list(any)
   description = "(Optional) The capacity_provider_strategy configuration block. This is a list of maps, where each map should contain \"capacity_provider \", \"weight\" and \"base\""
   default     = []
 }
 
 variable "placement_constraints" {
-  type        = list
+  type        = list(any)
   description = "(Optional) A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement_constraints is 10. This is a list of maps, where each map should contain \"type\" and \"expression\""
   default     = []
 }
 
 variable "proxy_configuration" {
-  type        = list
+  type        = list(any)
   description = "(Optional) The proxy configuration details for the App Mesh proxy. This is a list of maps, where each map should contain \"container_name\", \"properties\" and \"type\""
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -40,11 +40,6 @@ variable "task_container_image" {
   type        = string
 }
 
-variable "lb_arn" {
-  description = "Arn for the LB for which the service should be attach to."
-  type        = string
-}
-
 variable "desired_count" {
   description = "The number of instances of the task definitions to place and keep running."
   default     = 1
@@ -142,7 +137,7 @@ variable "deployment_maximum_percent" {
 variable "deployment_controller_type" {
   default     = "ECS"
   type        = string
-  description = "Type of deployment controller. Valid values: CODE_DEPLOY, ECS."
+  description = "Type of deployment controller. Valid values: CODE_DEPLOY, ECS, EXTERNAL. Default: ECS."
 }
 
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html
@@ -175,10 +170,10 @@ variable "propogate_tags" {
   default     = "TASK_DEFINITION"
 }
 
-variable "target_group_name" {
-  type        = string
-  default     = ""
-  description = "The name for the tasks target group"
+variable "target_groups" {
+  type        = any
+  default     = []
+  description = "The name of the target groups to associate with ecs service"
 }
 
 variable "load_balanced" {


### PR DESCRIPTION
# Description

**New Feature:**
- Added functionality to allow the ability to register multiple target groups for an ECS service. Read more here: [Register multiple target groups](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/register-multiple-targetgroups.html)

It is now **required** to set `target_groups` if you want to register a target group(s) to ECS Service else set `loadbalanced = false`. 

**Fixes & Improvements:**
- Upgrades and cleanups in examples
- Switch to using default VPC and subnets in examples
- New example to demonstrate multiple target groups for ECS service
- Remove any unused variables

