### PR TITLE
Add missing 'target_group_name' parameter in examples

### DIFF
--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -103,7 +103,8 @@ module "fargate" {
 
   target_groups = [
     {
-      container_port = 80
+      target_group_name = "tg-example"
+      container_port    = 80
     }
   ]
 

--- a/examples/fargate-efs/main.tf
+++ b/examples/fargate-efs/main.tf
@@ -107,7 +107,8 @@ module "fargate" {
 
   target_groups = [
     {
-      container_port = 80
+      target_group_name = "efs-example"
+      container_port    = 80
     }
   ]
 

--- a/examples/fargate-spot/main.tf
+++ b/examples/fargate-spot/main.tf
@@ -95,7 +95,8 @@ module "fargate" {
 
   target_groups = [
     {
-      container_port = 80
+      target_group_name = "spot-example"
+      container_port    = 80
     }
   ]
 


### PR DESCRIPTION
# Description

Updating examples with `target_group_name` parameter.