### PR TITLE
Add support to pick latest task definition

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -91,3 +91,7 @@ data "aws_iam_policy_document" "read_repository_credentials" {
     ]
   }
 }
+
+data "aws_ecs_task_definition" "task" {
+  task_definition = aws_ecs_task_definition.task.family
+}

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,10 @@ locals {
   ]
 }
 
+data "aws_ecs_task_definition" "task" {
+  task_definition = aws_ecs_task_definition.task.family
+}
+
 resource "aws_ecs_task_definition" "task" {
   family                   = var.name_prefix
   execution_role_arn       = aws_iam_role.execution.arn
@@ -285,7 +289,7 @@ resource "aws_ecs_service" "service" {
   name = var.name_prefix
 
   cluster         = var.cluster_id
-  task_definition = aws_ecs_task_definition.task.arn
+  task_definition = "${aws_ecs_task_definition.task.family}:${max(aws_ecs_task_definition.task.revision, data.aws_ecs_task_definition.task.revision)}"
 
   desired_count  = var.desired_count
   propagate_tags = var.propogate_tags

--- a/main.tf
+++ b/main.tf
@@ -141,10 +141,6 @@ locals {
   ]
 }
 
-data "aws_ecs_task_definition" "task" {
-  task_definition = aws_ecs_task_definition.task.family
-}
-
 resource "aws_ecs_task_definition" "task" {
   family                   = var.name_prefix
   execution_role_arn       = aws_iam_role.execution.arn


### PR DESCRIPTION
# Description

Fetches the latest task definition and supplies that to ECS service definition to avoid issues in case an external CI/CD system is involved.
Fixes issue https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/40