### PR TITLE
Make deregistration_delay attribute customizable for ALB Target Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- Make deregistration_delay attribute customizable for ALB Target Groups
+
+
+<a name="6.2.1"></a>
+## [6.2.1] - 2021-07-30
+
+- Add support to pick latest task definition ([#41](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/41))
+
+
+<a name="6.2.0"></a>
+## [6.2.0] - 2021-06-04
+
+- add tags iam role ([#34](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/34))
+
+
+<a name="6.1.0"></a>
+## [6.1.0] - 2021-05-10
+
+- Add support for enable_execute_command ([#33](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/33))
 
 
 <a name="6.0.0"></a>
@@ -181,7 +200,10 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.0.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.2.1...HEAD
+[6.2.1]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.2.0...6.2.1
+[6.2.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.1.0...6.2.0
+[6.1.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.0.0...6.1.0
 [6.0.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/5.1.0...6.0.0
 [5.1.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/5.0.1...5.1.0
 [5.0.1]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/5.0.0...5.0.1

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ No modules.
 | [aws_lb_target_group.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_security_group.ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.egress_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_ecs_task_definition.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) | data source |
 | [aws_iam_policy_document.read_repository_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task_ecs_exec_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/main.tf
+++ b/main.tf
@@ -95,11 +95,12 @@ resource "aws_security_group_rule" "egress_service" {
 resource "aws_lb_target_group" "task" {
   for_each = var.load_balanced ? { for tg in var.target_groups : tg.target_group_name => tg } : {}
 
-  name        = lookup(each.value, "target_group_name")
-  vpc_id      = var.vpc_id
-  protocol    = var.task_container_protocol
-  port        = lookup(each.value, "container_port", var.task_container_port)
-  target_type = "ip"
+  name                 = lookup(each.value, "target_group_name")
+  vpc_id               = var.vpc_id
+  protocol             = var.task_container_protocol
+  port                 = lookup(each.value, "container_port", var.task_container_port)
+  deregistration_delay = lookup(each.value, "deregistration_delay", null)
+  target_type          = "ip"
 
 
   dynamic "health_check" {


### PR DESCRIPTION
# Description

The `deregistration_delay` attribute of a Target Group is set to 300 seconds by default (1)
as a conservatively safe value. However, if a service owner knows that their connections stop faster
it makes sense to reduce the delay to speed up deployments. This PR makes the customization
possible via the module.

Please let me know if you need me to update any additional files (i.e. CHANGELOG.md)

[1] https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#deregistration_delay