### PR TITLE
add ephemeral_storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,13 @@ resource "aws_ecs_task_definition" "task" {
   memory                   = var.task_definition_memory
   task_role_arn            = aws_iam_role.task.arn
 
+  dynamic "ephemeral_storage" {
+    for_each = var.task_definition_ephemeral_storage == 0 ? [] : [var.task_definition_ephemeral_storage]
+    content {
+      size_in_gib = var.task_definition_ephemeral_storage
+    }
+  }
+  
   container_definitions = <<EOF
 [{
   "name": "${var.container_name != "" ? var.container_name : var.name_prefix}",

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,12 @@ variable "task_definition_memory" {
   type        = number
 }
 
+variable "task_definition_ephemeral_storage" {
+  description = "The total amount, in GiB, of ephemeral storage to set for the task."
+  default     = 0
+  type        = number
+}
+
 variable "task_container_command" {
   description = "The command that is passed to the container."
   default     = []


### PR DESCRIPTION
# Description

Add the `ephemeral_storage` variable to the task definition.

Relevant references: 

* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#ephemeral_storage