### PR TITLE
Refactor examples to work with provider 4.0.0+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.61.0
+  rev: v1.64.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- fix: setting task_health_command to null
+- fix: setting `task_health_command` to null ([#49](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/49))
 
 
 <a name="6.4.1"></a>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<!-- markdownlint-disable MD041 -->
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/umotif-public/terraform-aws-ecs-fargate?style=social)](https://github.com/umotif-public/terraform-aws-ecs-fargate/releases/latest)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/umotif-public/terraform-aws-ecs-fargate)](https://github.com/umotif-public/terraform-aws-ecs-fargate/releases/latest)
 
 # Terraform AWS ECS Fargate
 
@@ -17,15 +16,19 @@ Terraform 0.13. Pin module version to `~> v6.0`. Submit pull-requests to `master
 resource "aws_ecs_cluster" "cluster" {
   name = "example-ecs-cluster"
 
+  setting {
+    name  = "containerInsights"
+    value = "disabled"
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "cluster" {
+  cluster_name = aws_ecs_cluster.cluster.name
+
   capacity_providers = ["FARGATE_SPOT", "FARGATE"]
 
   default_capacity_provider_strategy {
     capacity_provider = "FARGATE_SPOT"
-  }
-
-  setting {
-    name  = "containerInsights"
-    value = "disabled"
   }
 }
 
@@ -81,7 +84,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34 |
 
 ## Providers

--- a/examples/fargate-spot/main.tf
+++ b/examples/fargate-spot/main.tf
@@ -9,8 +9,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 #####
@@ -24,7 +27,7 @@ module "alb" {
   load_balancer_type = "application"
   internal           = false
   vpc_id             = data.aws_vpc.default.id
-  subnets            = data.aws_subnet_ids.all.ids
+  subnets            = data.aws_subnets.all.ids
 }
 
 resource "aws_lb_listener" "alb_80" {
@@ -64,16 +67,21 @@ resource "aws_security_group_rule" "task_ingress_80" {
 # ECS cluster and fargate
 #####
 resource "aws_ecs_cluster" "cluster" {
-  name               = "ecs-spot-test"
-  capacity_providers = ["FARGATE_SPOT", "FARGATE"]
-
-  default_capacity_provider_strategy {
-    capacity_provider = "FARGATE_SPOT"
-  }
+  name = "ecs-spot-test"
 
   setting {
     name  = "containerInsights"
     value = "disabled"
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "cluster" {
+  cluster_name = aws_ecs_cluster.cluster.name
+
+  capacity_providers = ["FARGATE_SPOT", "FARGATE"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
   }
 }
 
@@ -82,7 +90,7 @@ module "fargate" {
 
   name_prefix        = "ecs-fargate-example"
   vpc_id             = data.aws_vpc.default.id
-  private_subnet_ids = data.aws_subnet_ids.all.ids
+  private_subnet_ids = data.aws_subnets.all.ids
 
   cluster_id = aws_ecs_cluster.cluster.id
 

--- a/examples/multiple-target-groups/main.tf
+++ b/examples/multiple-target-groups/main.tf
@@ -9,8 +9,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 #####
@@ -24,7 +27,7 @@ module "external-alb" {
   load_balancer_type = "application"
   internal           = false
   vpc_id             = data.aws_vpc.default.id
-  subnets            = data.aws_subnet_ids.all.ids
+  subnets            = data.aws_subnets.all.ids
 }
 
 resource "aws_lb_listener" "external_alb_80" {
@@ -46,7 +49,7 @@ module "internal-alb" {
   load_balancer_type = "application"
   internal           = false
   vpc_id             = data.aws_vpc.default.id
-  subnets            = data.aws_subnet_ids.all.ids
+  subnets            = data.aws_subnets.all.ids
 }
 
 resource "aws_lb_listener" "internal_alb_80" {
@@ -128,7 +131,7 @@ module "fargate" {
   # sg_name_prefix     = "my-security-group-name" # uncomment if you want to name security group with specific name
 
   vpc_id             = data.aws_vpc.default.id
-  private_subnet_ids = data.aws_subnet_ids.all.ids
+  private_subnet_ids = data.aws_subnets.all.ids
   cluster_id         = aws_ecs_cluster.cluster.id
   target_groups = [
     {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.13.7"
 
   required_providers {
     aws = ">= 3.34"


### PR DESCRIPTION
# Description

This PR was to ensure the module is 4.0.0 compatible. 

Minor set of updates: 
1. Use the latest pre-commit version
2. Refactor `capacity_providers` attribute within `aws_ecs_cluster` resource to use `aws_ecs_cluster_capacity_providers` resource.
3. Update minimum terraform version to `0.13.7`