### PR TITLE
Enable containerDefinitions portMappings to use target_groups container_ports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.2.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -17,8 +17,8 @@ repos:
   - id: detect-aws-credentials
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
-- repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.64.0
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.71.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- removed whitespace
+- added distinct function to prevent a port being used multiple times
+- Added checks to ensure that errors are not generated when target_group ports mapping is used
+- Updated variable name
+- Updated file to prefer target_group ports if provided, else use task_container_port
+
+
+<a name="6.4.2"></a>
+## [6.4.2] - 2022-03-11
+
+- Refactor examples to work with provider 4.0.0+ ([#53](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/53))
 - fix: setting `task_health_command` to null ([#49](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/49))
 
 
@@ -224,7 +235,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.4.1...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.4.2...HEAD
+[6.4.2]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.4.1...6.4.2
 [6.4.1]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.4.0...6.4.1
 [6.4.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.3.0...6.4.0
 [6.3.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.2.2...6.3.0

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ module "ecs-fargate" {
 
 ## Authors
 
-Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](https://www.linkedin.com/in/marcincuber/).
+Module managed by [Abdul Wahid](https://github.com/Ohid25) [LinkedIn](https://www.linkedin.com/in/abdulwahid/).
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -85,13 +85,13 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
 
 ## Modules
 

--- a/examples/multiple-target-groups/main.tf
+++ b/examples/multiple-target-groups/main.tf
@@ -136,7 +136,7 @@ module "fargate" {
   target_groups = [
     {
       target_group_name = "external-alb"
-      container_port    = 80
+      container_port    = 443
     },
     {
       target_group_name = "internal-alb"
@@ -186,4 +186,3 @@ resource "aws_security_group_rule" "test_sg_ingress" {
   to_port                  = 3022
   source_security_group_id = module.fargate.service_sg_id
 }
-

--- a/main.tf
+++ b/main.tf
@@ -176,8 +176,8 @@ resource "aws_ecs_task_definition" "task" {
   %{~endif}
   "essential": true,
   
-  %{if length(local.portMaps) > 0 }
-  "portMappings": ${jsonencode(local.portMaps)},
+  %{if length(local.target_group_portMaps) > 0 }
+  "portMappings": ${jsonencode(local.portarget_group_portMapstMaps)},
   %{else}
   %{if var.task_container_port != 0 || var.task_host_port != 0~}
   "portMappings": [

--- a/main.tf
+++ b/main.tf
@@ -175,7 +175,6 @@ resource "aws_ecs_task_definition" "task" {
   },
   %{~endif}
   "essential": true,
-  
   %{if length(local.target_group_portMaps) > 0 }
   "portMappings": ${jsonencode(local.target_group_portMaps)},
   %{else}

--- a/main.tf
+++ b/main.tf
@@ -141,12 +141,12 @@ locals {
     }
   ]
 
-  target_group_portMaps = length(var.target_groups) > 0 ? [
+  target_group_portMaps = length(var.target_groups) > 0 ? distinct([
     for tg in var.target_groups: {
       containerPort = contains(keys(tg), "container_port") ? tg.container_port : var.task_container_port
       protocol = contains(keys(tg), "protocol") ?  lower(tg.protocol) : "tcp"
     }
-  ] : []
+  ]) : []
 }
 
 resource "aws_ecs_task_definition" "task" {

--- a/main.tf
+++ b/main.tf
@@ -141,12 +141,12 @@ locals {
     }
   ]
 
-  target_group_portMaps = [
+  target_group_portMaps = length(var.target_groups) > 0 ? [
     for tg in var.target_groups: {
-      containerPort = tg.container_port
-      protocol = lower(tg.protocol) 
+      containerPort = contains(keys(tg), "container_port") ? tg.container_port : var.task_container_port
+      protocol = contains(keys(tg), "protocol") ?  lower(tg.protocol) : "tcp"
     }
-  ]
+  ] : []
 }
 
 resource "aws_ecs_task_definition" "task" {
@@ -177,7 +177,7 @@ resource "aws_ecs_task_definition" "task" {
   "essential": true,
   
   %{if length(local.target_group_portMaps) > 0 }
-  "portMappings": ${jsonencode(local.portarget_group_portMapstMaps)},
+  "portMappings": ${jsonencode(local.target_group_portMaps)},
   %{else}
   %{if var.task_container_port != 0 || var.task_host_port != 0~}
   "portMappings": [

--- a/main.tf
+++ b/main.tf
@@ -142,9 +142,9 @@ locals {
   ]
 
   target_group_portMaps = length(var.target_groups) > 0 ? distinct([
-    for tg in var.target_groups: {
+    for tg in var.target_groups : {
       containerPort = contains(keys(tg), "container_port") ? tg.container_port : var.task_container_port
-      protocol = contains(keys(tg), "protocol") ?  lower(tg.protocol) : "tcp"
+      protocol      = contains(keys(tg), "protocol") ? lower(tg.protocol) : "tcp"
     }
   ]) : []
 }
@@ -175,7 +175,7 @@ resource "aws_ecs_task_definition" "task" {
   },
   %{~endif}
   "essential": true,
-  %{if length(local.target_group_portMaps) > 0 }
+  %{if length(local.target_group_portMaps) > 0}
   "portMappings": ${jsonencode(local.target_group_portMaps)},
   %{else}
   %{if var.task_container_port != 0 || var.task_host_port != 0~}

--- a/main.tf
+++ b/main.tf
@@ -140,6 +140,13 @@ locals {
       value = v
     }
   ]
+
+  target_group_portMaps = [
+    for tg in var.target_groups: {
+      containerPort = tg.container_port
+      protocol = lower(tg.protocol) 
+    }
+  ]
 }
 
 resource "aws_ecs_task_definition" "task" {
@@ -168,6 +175,10 @@ resource "aws_ecs_task_definition" "task" {
   },
   %{~endif}
   "essential": true,
+  
+  %{if length(local.portMaps) > 0 }
+  "portMappings": ${jsonencode(local.portMaps)},
+  %{else}
   %{if var.task_container_port != 0 || var.task_host_port != 0~}
   "portMappings": [
     {
@@ -180,6 +191,7 @@ resource "aws_ecs_task_definition" "task" {
       "protocol":"tcp"
     }
   ],
+  %{~endif}
   %{~endif}
   "logConfiguration": {
     "logDriver": "awslogs",

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 3.34"
+    aws = ">= 4.0.0"
   }
 }


### PR DESCRIPTION
# Description

This commit enables the module to prefer the `target_groups` list of `container_port` and `protocol` over `task_container_port`.

If the target_groups does not have port and protocol specified, current behavior continues.