### PR TITLE
Add entrypoint to task definition parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ terraform.tfstate
 *.tfstate*
 terraform.tfvars
 *.terraform.lock.hcl
+*.vscode*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v4.3.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.71.0
+  rev: v1.74.1
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- add GetBucketLocation permissions to iam policy
-- add iam permissions
-- Add support for environment files
+
+
+<a name="6.5.0"></a>
+## [6.5.0] - 2022-05-12
+
+- Add support for EnvironmentFiles in container definition ([#60](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/60))
 - Allow option to customise run_time platform ([#56](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/56))
 - Enable containerDefinitions portMappings to use target_groups container_ports ([#59](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/59))
 
@@ -235,7 +238,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.4.2...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.5.0...HEAD
+[6.5.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.4.2...6.5.0
 [6.4.2]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.4.1...6.4.2
 [6.4.1]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.4.0...6.4.1
 [6.4.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.3.0...6.4.0

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Module managed by [Abdul Wahid](https://github.com/Ohid25) [LinkedIn](https://ww
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 
 ## Providers
@@ -160,6 +160,7 @@ No modules.
 | <a name="input_task_container_assign_public_ip"></a> [task\_container\_assign\_public\_ip](#input\_task\_container\_assign\_public\_ip) | Assigned public IP to the container. | `bool` | `false` | no |
 | <a name="input_task_container_command"></a> [task\_container\_command](#input\_task\_container\_command) | The command that is passed to the container. | `list(string)` | `[]` | no |
 | <a name="input_task_container_cpu"></a> [task\_container\_cpu](#input\_task\_container\_cpu) | Amount of CPU to reserve for the container. | `number` | `null` | no |
+| <a name="input_task_container_entrypoint"></a> [task\_container\_entrypoint](#input\_task\_container\_entrypoint) | The entrypoint that is passed to the container. | `list(string)` | `[]` | no |
 | <a name="input_task_container_environment"></a> [task\_container\_environment](#input\_task\_container\_environment) | The environment variables to pass to a container. | `map(string)` | `{}` | no |
 | <a name="input_task_container_environment_files"></a> [task\_container\_environment\_files](#input\_task\_container\_environment\_files) | The environment variable files (s3 object arns) to pass to a container. Files must use .env file extension. | `list(string)` | `[]` | no |
 | <a name="input_task_container_image"></a> [task\_container\_image](#input\_task\_container\_image) | The image used to start a container. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module to create [AWS ECS FARGATE](https://aws.amazon.com/fargate/) se
 
 ## Terraform versions
 
-Terraform 0.13. Pin module version to `~> v6.0`. Submit pull-requests to `master` branch.
+Terraform 1.0.11. Pin module version to `~> v6.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
@@ -77,7 +77,7 @@ module "ecs-fargate" {
 
 ## Authors
 
-Module managed by [Abdul Wahid](https://github.com/Ohid25) [LinkedIn](https://www.linkedin.com/in/abdulwahid/).
+Module managed by [uMotif](https://github.com/umotif-public/).
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -93,7 +93,7 @@ module "fargate" {
   private_subnet_ids = data.aws_subnets.all.ids
   cluster_id         = aws_ecs_cluster.cluster.id
 
-  wait_for_steady_state = true
+  wait_for_steady_state = false
 
   platform_version = "1.4.0" # defaults to LATEST
 
@@ -126,7 +126,6 @@ module "fargate" {
   # create_repository_credentials_iam_policy = false
   # repository_credentials                   = aws_secretsmanager_secret.task_credentials.arn
 }
-
 
 resource "aws_security_group" "allow_sg_test" {
   name        = "allow_sg_test"

--- a/main.tf
+++ b/main.tf
@@ -225,6 +225,9 @@ resource "aws_ecs_task_definition" "task" {
   },
   %{~endif}
   "command": ${jsonencode(var.task_container_command)},
+  %{if var.task_container_entrypoint != ""~}
+  "entryPoint": ${jsonencode(var.task_container_entrypoint)},
+  %{~endif}
   %{if var.task_container_working_directory != ""~}
   "workingDirectory": ${var.task_container_working_directory},
   %{~endif}

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "task_container_command" {
   type        = list(string)
 }
 
+variable "task_container_entrypoint" {
+  description = "The entrypoint that is passed to the container."
+  default     = []
+  type        = list(string)
+}
+
 variable "task_container_environment" {
   description = "The environment variables to pass to a container."
   default     = {}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.7"
+  required_version = ">= 1.0.11"
 
   required_providers {
     aws = ">= 4.0.0"


### PR DESCRIPTION
# Description

- feature: Adding `entryPoint` to [task definitions parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_environment)
- chore: update pre-commit version
- chore: update minimum terraform CLI version
