### PR TITLE
Add readonlyRootFilesystem to container_definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,8 @@ resource "aws_ecs_task_definition" "task" {
   "pseudoTerminal": ${var.task_pseudo_terminal},
   %{~endif}
   "environment": ${jsonencode(local.task_environment)},
-  "environmentFiles": ${jsonencode(local.task_environment_files)}
+  "environmentFiles": ${jsonencode(local.task_environment_files)},
+  "readonlyRootFilesystem": ${var.readonlyRootFilesystem ? true : false}
 }]
 EOF
 

--- a/variables.tf
+++ b/variables.tf
@@ -333,3 +333,8 @@ variable "cpu_architecture" {
   default     = "X86_64"
   type        = string
 }
+
+variable "readonlyRootFilesystem" {
+  default     = false
+  description = "When this parameter is true, the container is given read-only access to its root file system"
+}


### PR DESCRIPTION
# Description

Add readonlyRootFilesystem to container_definition. It's required by AWS security assessment. 