### PR TITLE
Make egress rule configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ No modules.
 | <a name="input_volume"></a> [volume](#input\_volume) | (Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain "name", "host\_path", "docker\_volume\_configuration" and "efs\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html | `list(any)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID. | `string` | n/a | yes |
 | <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | If true, Terraform will wait for the service to reach a steady state (like aws ecs wait services-stable) before continuing. | `bool` | `false` | no |
+| <a name="deny_egress_to_anywhere"></a> [deny\_egress\_to\_anywhere](#deny\_egress\_to\_anywhere) | If true, Terraform will no create the default egress rule which allows all outgoing traffic. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ resource "aws_security_group" "ecs_service" {
 }
 
 resource "aws_security_group_rule" "egress_service" {
+  count             = var.deny_egress_to_anywhere ? 0 : 1
   security_group_id = aws_security_group.ecs_service.id
   type              = "egress"
   protocol          = "-1"

--- a/variables.tf
+++ b/variables.tf
@@ -345,3 +345,9 @@ variable "readonlyRootFilesystem" {
   description = "When this parameter is true, the container is given read-only access to its root file system"
   type        = bool
 }
+
+variable "deny_egress_to_anywhere" {
+  default     = false
+  description = "When this parameter is true, no default egress rule will be created"
+  type        = bool
+}


### PR DESCRIPTION
# Make default egress rule to be optional

Defined a new input variable which allow the user to create the default egress rule or not. This gives the opportunity to not allow all outgoing traffic. 

The Allow all outgoing traffic could be problematic for teams 
