### PR TITLE
Upgrade to 5.x + Fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.77.2
+  rev: v1.81.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,21 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Comment about 'target_type' for Fargate
-- Revert container name to original
-- Remove square brackets as input is a list
-- Lint fixes
-- Turn cloudwatch logging optional - fix
-- Turn cloudwatch logging optional
-- chore: Update documentation
-- Turn cloudwatch logging optional
-- Refactored container definitions out of module
+- fix: protocol set to HTTP by default
+- fix: setting container_name is now mandatory to utilise multiple container names set externally to module
+- chore: upgrade to 5.x compatibility
+
+
+<a name="7.0.0"></a>
+## [7.0.0] - 2023-04-12
+
+- Refactored container definitions out of module ([#69](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/69))
+
+
+<a name="6.7.1"></a>
+## [6.7.1] - 2023-03-28
+
+- Make egress rule configurable ([#71](https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/71))
 
 
 <a name="6.7.0"></a>
@@ -272,7 +278,9 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.7.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/7.0.0...HEAD
+[7.0.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.7.1...7.0.0
+[6.7.1]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.7.0...6.7.1
 [6.7.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.6.0...6.7.0
 [6.6.0]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.5.2...6.6.0
 [6.5.2]: https://github.com/umotif-public/terraform-aws-ecs-fargate/compare/6.5.1...6.5.2

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ Module managed by [uMotif](https://github.com/umotif-public/).
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6.0, < 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6.0, < 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6.0 |
 
 ## Modules
 

--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 1.0.11"
-
-  required_providers {
-    aws = ">= 4.6.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # VPC and subnets
 #####

--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -104,6 +104,7 @@ module "fargate" {
     {
       target_group_name = "tg-example"
       container_port    = 80
+      container_name    = "ecs-fargate-example" # should be equal to container_name in container definition
     }
   ]
 

--- a/examples/core/versions.tf
+++ b/examples/core/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.6.0"
+      version = "~> 5"
     }
   }
 }

--- a/examples/core/versions.tf
+++ b/examples/core/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "1.0.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/examples/external-container-definitions/main.tf
+++ b/examples/external-container-definitions/main.tf
@@ -152,7 +152,7 @@ module "fargate" {
 
   target_groups = [
     {
-      container_name    = "example"
+      container_name    = "example" # should be equal to container_name in container definition
       target_group_name = "tg-example"
       container_port    = 80
     }

--- a/examples/external-container-definitions/main.tf
+++ b/examples/external-container-definitions/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 1.0.11"
-
-  required_providers {
-    aws = ">= 4.8.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # VPC and subnets
 #####
@@ -48,7 +36,7 @@ resource "aws_ecs_cluster_capacity_providers" "cluster" {
 
 module "container_1" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.58.2"
+  version = "0.60.0"
 
   container_name  = "example"
   container_image = "hello-world:latest"
@@ -65,7 +53,7 @@ module "container_1" {
 
 module "container_2" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.58.2"
+  version = "0.60.0"
 
   container_name  = "example-2"
   container_image = "hello-world:latest"

--- a/examples/external-container-definitions/versions.tf
+++ b/examples/external-container-definitions/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6.0"
+      version = "~> 5"
     }
   }
 }

--- a/examples/external-container-definitions/versions.tf
+++ b/examples/external-container-definitions/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/examples/fargate-efs/main.tf
+++ b/examples/fargate-efs/main.tf
@@ -112,6 +112,7 @@ module "fargate" {
     {
       target_group_name = "efs-example"
       container_port    = 80
+      container_name    = "ecs-fargate-example"
     }
   ]
 

--- a/examples/fargate-efs/main.tf
+++ b/examples/fargate-efs/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 1.0.11"
-
-  required_providers {
-    aws = ">= 4.8.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # VPC and subnets
 #####
@@ -86,7 +74,7 @@ resource "aws_efs_file_system" "efs" {
 # ECS cluster and fargate
 #####
 resource "aws_ecs_cluster" "cluster" {
-  name = "ecs-spot-test"
+  name = "ecs-efs-test"
   setting {
     name  = "containerInsights"
     value = "disabled"

--- a/examples/fargate-efs/versions.tf
+++ b/examples/fargate-efs/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/examples/fargate-efs/versions.tf
+++ b/examples/fargate-efs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6.0"
+      version = "~> 5"
     }
   }
 }

--- a/examples/fargate-spot/main.tf
+++ b/examples/fargate-spot/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 1.0.11"
-
-  required_providers {
-    aws = ">= 4.6.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # VPC and subnets
 #####

--- a/examples/fargate-spot/versions.tf
+++ b/examples/fargate-spot/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/examples/fargate-spot/versions.tf
+++ b/examples/fargate-spot/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6.0"
+      version = "~> 5"
     }
   }
 }

--- a/examples/multiple-target-groups/main.tf
+++ b/examples/multiple-target-groups/main.tf
@@ -133,10 +133,12 @@ module "fargate" {
     {
       target_group_name = "external-alb"
       container_port    = 443
+      container_name    = "ecs-fargate-example"
     },
     {
       target_group_name = "internal-alb"
       container_port    = 80
+      container_name    = "ecs-fargate-example"
     }
   ]
 

--- a/examples/multiple-target-groups/main.tf
+++ b/examples/multiple-target-groups/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 1.0.11"
-
-  required_providers {
-    aws = ">= 4.6.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # VPC and subnets
 #####

--- a/examples/multiple-target-groups/versions.tf
+++ b/examples/multiple-target-groups/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/examples/multiple-target-groups/versions.tf
+++ b/examples/multiple-target-groups/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6.0"
+      version = "~> 5"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -292,7 +292,7 @@ resource "aws_ecs_service" "service" {
   dynamic "load_balancer" {
     for_each = var.load_balanced ? var.target_groups : []
     content {
-      container_name   = var.container_name != "" ? var.container_name : var.name_prefix
+      container_name   = try(load_balancer.value, "container_name") != "" ? lookup(load_balancer.value, "container_name") : var.name_prefix
       container_port   = lookup(load_balancer.value, "container_port", var.task_container_port)
       target_group_arn = aws_lb_target_group.task[lookup(load_balancer.value, "target_group_name")].arn
     }

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ resource "aws_lb_target_group" "task" {
       interval            = lookup(health_check.value, "interval", 30)
       path                = lookup(health_check.value, "path", "/")
       port                = lookup(health_check.value, "port", "traffic-port")
-      protocol            = lookup(health_check.value, "protocol", "TCP")
+      protocol            = lookup(health_check.value, "protocol", "HTTP")
       timeout             = lookup(health_check.value, "timeout", 5)
       healthy_threshold   = lookup(health_check.value, "healthy_threshold", 5)
       unhealthy_threshold = lookup(health_check.value, "unhealthy_threshold", 2)

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 1.0.11"
 
   required_providers {
-    aws = ">= 4.6.0, < 5.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6.0"
+    }
   }
 }


### PR DESCRIPTION
# Description

Module is now 5.x compatibile

**BREAKING CHANGE**
`container_name` now must be set for target_group. 

This variable can be set via `var.container_name` or can be set via `var.name_prefix`. 

The purpose behind this change is to accommodate the requirement of using an external container definition where the container name(s) are set externally to the module and, therefore, must be set within `target_group`.